### PR TITLE
Keep assets cache as is

### DIFF
--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -95,7 +95,6 @@ WARNING
           log "assets_precompile", :status => "success"
           puts "Asset precompilation completed (#{"%.2f" % precompile.time}s)"
 
-          cleanup_assets_cache
           @cache.store public_assets_folder
           @cache.store default_assets_cache
         else


### PR DESCRIPTION
There is no point in partially removing assets cache because we don't share it natively between builds, but it prevents us from actually caching and re-using all the assets between builds via Cloud Storage.